### PR TITLE
Change default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Clone repos into the right directory in your workspace
 
-The "right" directory is a path computed by klone. It take the URL you're cloning from an turns it into a deterministic
+The "right" directory is a path computed by klone. It takes the URL you're cloning from an turns it into a deterministic
 path. E.g. `https://github.com/kfkonrad/klone` would get cloned to `~/workspace/github/kfkonrad/klone`. The exact
 behavior is configurable, see [Usage](#usage) for more.
 
@@ -45,17 +45,17 @@ examples for installing the script using `curl` and `wget` for added convenience
 Install with `curl`:
 
 ```sh
-mkdir -p ~/.config/
-curl https://raw.githubusercontent.com/kfkonrad/klone/main/bash/klone.sh -so ~/.config/klone.sh
-echo 'source ~/.config/klone.sh' >> ~/.bashrc
+mkdir -p ~/.config/klone
+curl https://raw.githubusercontent.com/kfkonrad/klone/main/bash/klone.sh -so ~/.config/klone/klone.sh
+echo 'source ~/.config/klone/klone.sh' >> ~/.bashrc
 ```
 
 Install with `wget`:
 
 ```sh
-mkdir -p ~/.config/
-wget https://raw.githubusercontent.com/kfkonrad/klone/main/bash/klone.sh -qO ~/.config/klone.sh
-echo 'source ~/.config/klone.sh' >> ~/.bashrc
+mkdir -p ~/.config/klone
+wget https://raw.githubusercontent.com/kfkonrad/klone/main/bash/klone.sh -qO ~/.config/klone/klone.sh
+echo 'source ~/.config/klone/klone.sh' >> ~/.bashrc
 ```
 
 ### ZSH
@@ -67,24 +67,24 @@ examples for installing the script using `curl` and `wget` for added convenience
 Install with `curl`:
 
 ```sh
-mkdir -p ~/.config/
-curl https://raw.githubusercontent.com/kfkonrad/klone/main/zsh/klone.sh -so ~/.config/klone.sh
-echo 'source ~/.config/klone.sh' >> ~/.zshrc
+mkdir -p ~/.config/klone
+curl https://raw.githubusercontent.com/kfkonrad/klone/main/zsh/klone.sh -so ~/.config/klone/klone.sh
+echo 'source ~/.config/klone/klone.sh' >> ~/.zshrc
 ```
 
 Install with `wget`:
 
 ```sh
-mkdir -p ~/.config/
-wget https://raw.githubusercontent.com/kfkonrad/klone/main/zsh/klone.sh -qO ~/.config/klone.sh
-echo 'source ~/.config/klone.sh' >> ~/.zshrc
+mkdir -p ~/.config/klone
+wget https://raw.githubusercontent.com/kfkonrad/klone/main/zsh/klone.sh -qO ~/.config/klone/klone.sh
+echo 'source ~/.config/klone/klone.sh' >> ~/.zshrc
 ```
 
 ## Usage
 
 To clone a repo simply run `klone <URL>`. `klone` supports SSH, git and HTTPS URLs with the same format `git` uses.
 
-`klone` is configured with a TOML file. By default it's expected to be in `~/.config/klone.toml`, though you can
+`klone` is configured with a TOML file. By default it's expected to be in `~/.config/klone/config.toml`, though you can
 override this by setting `KLONE_CONFIG`.
 
 The TOML config has three sections: `[general]`, `[domain_alias]` and `[path_replace]`.
@@ -101,7 +101,7 @@ This section has three keys and changes the behavior of `klone` for all URLs:
 
 ### `[domain_alias]`
 
-In `[domain_alias]` you can alias domains to arbitrary strings. This allows you to change the part of the reopo's path
+In `[domain_alias]` you can alias domains to arbitrary strings. This allows you to change the part of the repo's path
 that's calculated from the URL. By default this is the first part of the FQDN up until the first dot, e.g. `github.com`
 -> `github` or `foo.example.com` -> foo.
 
@@ -120,7 +120,7 @@ The format for this is `<domain> = ["replace_me", "with_this"]`.
 Do not format the array into multiple lines, the TOML parsers implemented in Bash/ZSH/Fish for this project do not have
 multi-line support.
 
-### Example `klone.toml`
+### Example `config.toml`
 
 ```toml
 [domain_alias]
@@ -139,12 +139,12 @@ is finished, the user's shell would `cd` into `~/code/foo/bar/kfkonrad/klone`.
 
 Running `klone https://gitlab.com/rluna-database/nosql/mongodb/mongo` with the config above would clone the repo into
 `~/code/gitlab/baz-database/nosql/mongodb/mongo` using
-`jj git clone --colocate https://gitlab.com/rluna-database/nosql/mongodb/mongo`. Afterwords `klone` would `cd` into
+`jj git clone --colocate https://gitlab.com/rluna-database/nosql/mongodb/mongo`. Afterwards `klone` would `cd` into
 `~/code/gitlab/baz-database/nosql/mongodb/mongo`.
 
 The `clone_command` is always run from the parent of the target directory (`~/code/foo/bar/kfkonrad/` in this case),
-since that has the broaded compatibility with other version control systems such as Subversion, Jujutsu, Mercurial etc.
-This also means the `clone_command` is run as is and only the URL is supplied as an additional argument
+since that has the broadest compatibility with other version control systems such as Subversion, Jujutsu, Mercurial etc.
+This also means the `clone_command` is run as is and only the URL is supplied as an additional argument.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Clone repos into the right directory in your workspace
 
-The "right" directory is a path computed by klone. It takes the URL you're cloning from an turns it into a deterministic
+The "right" directory is a path computed by klone. It takes the URL you're cloning from and turns it into a deterministic
 path. E.g. `https://github.com/kfkonrad/klone` would get cloned to `~/workspace/github/kfkonrad/klone`. The exact
 behavior is configurable, see [Usage](#usage) for more.
 

--- a/bash/klone.sh
+++ b/bash/klone.sh
@@ -20,9 +20,10 @@ klone() {
 }
 
 __klone_helper_toml_file() {
-    if [[ -n ${KLONE_CONFIG} ]]; then
-        echo "${KLONE_CONFIG}"
-    else
+    local config_path="${KLONE_CONFIG:-$HOME/.config/klone/config.toml}"
+    if [[ -f ${config_path} ]]; then
+        echo "${config_path}"
+    elif [[ -f $HOME/.config/klone.toml ]]; then
         echo $HOME/.config/klone.toml
     fi
 }
@@ -119,35 +120,36 @@ __klone_helper_parse_toml() {
     # Clear any existing TOML variables
     __klone_helper_cleanup_vars
 
-    while IFS= read -r line; do
+    if [[ -f $file ]]; then
+        while IFS= read -r line; do
+            # Skip empty lines and comments
+            [[ -z "$line" || "$line" =~ ^# ]] && continue
 
-        # Skip empty lines and comments
-        [[ -z "$line" || "$line" =~ ^# ]] && continue
-
-        # Match section headers
-        if [[ "$line" =~ ^\[(.*)\]$ ]]; then
-            current_section="${BASH_REMATCH[1]}"
-            continue
-        fi
-
-        # Match key-value pairs
-        if [[ "$line" =~ ^([a-zA-Z0-9_.]+)[[:space:]]*=[[:space:]]*(.*)$ ]]; then
-            local key="${BASH_REMATCH[1]}"
-            local value="${BASH_REMATCH[2]}"
-
-            # Remove surrounding quotes if present
-            if [[ "$value" =~ ^\"(.*)\"$ ]]; then
-                value="${BASH_REMATCH[1]}"
+            # Match section headers
+            if [[ "$line" =~ ^\[(.*)\]$ ]]; then
+                current_section="${BASH_REMATCH[1]}"
+                continue
             fi
 
-            local storage_key="klone_toml_$(__klone_helper_escape_key "${current_section}.${key}")"
-            if [[ "$value" =~ ^\[(.*)\]$ ]]; then
-                __klone_helper_parse_array "$value" "$storage_key"
-            else
-                export "$storage_key=$value"
+            # Match key-value pairs
+            if [[ "$line" =~ ^([a-zA-Z0-9_.]+)[[:space:]]*=[[:space:]]*(.*)$ ]]; then
+                local key="${BASH_REMATCH[1]}"
+                local value="${BASH_REMATCH[2]}"
+
+                # Remove surrounding quotes if present
+                if [[ "$value" =~ ^\"(.*)\"$ ]]; then
+                    value="${BASH_REMATCH[1]}"
+                fi
+
+                local storage_key="klone_toml_$(__klone_helper_escape_key "${current_section}.${key}")"
+                if [[ "$value" =~ ^\[(.*)\]$ ]]; then
+                    __klone_helper_parse_array "$value" "$storage_key"
+                else
+                    export "$storage_key=$value"
+                fi
             fi
-        fi
-    done < "$file"
+        done < "$file"
+    fi
 }
 
 # Function to parse array values

--- a/bash/klone.sh
+++ b/bash/klone.sh
@@ -23,8 +23,6 @@ __klone_helper_toml_file() {
     local config_path="${KLONE_CONFIG:-$HOME/.config/klone/config.toml}"
     if [[ -f ${config_path} ]]; then
         echo "${config_path}"
-    elif [[ -f $HOME/.config/klone.toml ]]; then
-        echo $HOME/.config/klone.toml
     fi
 }
 

--- a/functions/klone.fish
+++ b/functions/klone.fish
@@ -17,7 +17,7 @@ function klone
 end
 
 function __klone_helper_toml_file
-  if test -n "$KLONE_CONFIG" -a -f "$KLONE_CONFIG"
+  if set -q KLONE_CONFIG && test -f "$KLONE_CONFIG"
     echo "$KLONE_CONFIG"
   else if test -f "$HOME/.config/klone/config.toml"
     echo "$HOME/.config/klone/config.toml"
@@ -99,6 +99,7 @@ function __klone_helper_parse_toml
 
   # Clear any existing TOML variables
   __klone_helper_cleanup_vars
+
   if test -f "$file"
     while read -l line
       # Trim whitespace

--- a/functions/klone.fish
+++ b/functions/klone.fish
@@ -17,21 +17,19 @@ function klone
 end
 
 function __klone_helper_toml_file
-    if test -n "$KLONE_CONFIG" -a -f "$KLONE_CONFIG"
-        echo "$KLONE_CONFIG"
-    else if test -f "$HOME/.config/klone/config.toml"
-        echo "$HOME/.config/klone/config.toml"
-    else if test -f "$HOME/.config/klone.toml"
-        echo "$HOME/.config/klone.toml"
-    end
+  if test -n "$KLONE_CONFIG" -a -f "$KLONE_CONFIG"
+    echo "$KLONE_CONFIG"
+  else if test -f "$HOME/.config/klone/config.toml"
+    echo "$HOME/.config/klone/config.toml"
+  end
 end
 
 function __klone_helper_clone_tool
-    if set -q klone_toml_general_clone_command
-        echo "$klone_toml_general_clone_command"
-    else
-        echo git clone
-    end
+  if set -q klone_toml_general_clone_command
+    echo "$klone_toml_general_clone_command"
+  else
+    echo git clone
+  end
 end
 
 function __klone_helper_extract_full_path
@@ -83,68 +81,68 @@ end
 
 # Function to clean up environment variables when done
 function __klone_helper_cleanup_vars
-    set -l vars (set -n | string match -r "klone_toml_.*")
-    for var in $vars
-        set -e $var
-    end
+  set -l vars (set -n | string match -r "klone_toml_.*")
+  for var in $vars
+    set -e $var
+  end
 end
 
 # Function to escape special characters in keys
 function __klone_helper_escape_key
-    echo $argv[1] | sed 's/[.:-]/_/g'
+  echo $argv[1] | sed 's/[.:-]/_/g'
 end
 
 # Function to parse a TOML file
 function __klone_helper_parse_toml
-    set -l file $argv[1]
-    set -l current_section ""
+  set -l file $argv[1]
+  set -l current_section ""
 
-    # Clear any existing TOML variables
-    __klone_helper_cleanup_vars
-    if test -f "$file"
-        while read -l line
-            # Trim whitespace
-            set line (string trim $line)
-  
-            # Skip empty lines and comments
-            if test -z "$line" -o (string sub -l 1 "$line") = "#"
-                continue
-            end
-  
-            # Match section headers
-            if string match -qr '^\[(.*)\]$' "$line"
-                set current_section (string match -r '^\[(.*)\]$' "$line")[2]
-                continue
-            end
-  
-            # Match key-value pairs
-            if string match -qr '^([a-zA-Z0-9_.]+)\s*=\s*(.*)$' "$line"
-                set -l captures (string match -r '^([a-zA-Z0-9_.]+)\s*=\s*(.*)$' "$line")
-                set -l key $captures[2]
-                set -l value $captures[3]
-  
-                # Remove surrounding quotes if present
-                if string match -qr '^"(.*)"$' "$value"
-                    set value (string match -r '^"(.*)"$' "$value")[2]
-                end
-  
-                set -l storage_key "klone_toml_"(__klone_helper_escape_key "$current_section.$key")
-                if string match -qr '^\[(.*)\]$' "$value"
-                  __klone_helper_parse_array $value $storage_key
-                else
-                  set -g $storage_key $value
-                end
-            end
-        end < $file
-    end
+  # Clear any existing TOML variables
+  __klone_helper_cleanup_vars
+  if test -f "$file"
+    while read -l line
+      # Trim whitespace
+      set line (string trim $line)
+
+      # Skip empty lines and comments
+      if test -z "$line" -o (string sub -l 1 "$line") = "#"
+        continue
+      end
+
+      # Match section headers
+      if string match -qr '^\[(.*)\]$' "$line"
+        set current_section (string match -r '^\[(.*)\]$' "$line")[2]
+        continue
+      end
+
+      # Match key-value pairs
+      if string match -qr '^([a-zA-Z0-9_.]+)\s*=\s*(.*)$' "$line"
+        set -l captures (string match -r '^([a-zA-Z0-9_.]+)\s*=\s*(.*)$' "$line")
+        set -l key $captures[2]
+        set -l value $captures[3]
+
+        # Remove surrounding quotes if present
+        if string match -qr '^"(.*)"$' "$value"
+          set value (string match -r '^"(.*)"$' "$value")[2]
+        end
+
+        set -l storage_key "klone_toml_"(__klone_helper_escape_key "$current_section.$key")
+        if string match -qr '^\[(.*)\]$' "$value"
+          __klone_helper_parse_array $value $storage_key
+        else
+          set -g $storage_key $value
+        end
+      end
+    end < $file
+  end
 end
 
 function __klone_helper_parse_array
-    set -l parsed (string match -r '\[\s*"([^"]+)"\s*,\s*"([^"]+)"\s*\]' $argv[1])
-    set -l storage_key $argv[2]
+  set -l parsed (string match -r '\[\s*"([^"]+)"\s*,\s*"([^"]+)"\s*\]' $argv[1])
+  set -l storage_key $argv[2]
 
-    if test (count $parsed) -eq 3
-        set -g $storage_key"_0" $parsed[2]
-        set -g $storage_key"_1" $parsed[3]
-    end
+  if test (count $parsed) -eq 3
+    set -g $storage_key"_0" $parsed[2]
+    set -g $storage_key"_1" $parsed[3]
+  end
 end

--- a/zsh/klone.sh
+++ b/zsh/klone.sh
@@ -21,9 +21,10 @@ klone() {
 
 
 __klone_helper_toml_file() {
-    if [[ -n ${KLONE_CONFIG} ]]; then
-        echo "${KLONE_CONFIG}"
-    else
+    local config_path="${KLONE_CONFIG:-$HOME/.config/klone/config.toml}"
+    if [[ -f ${config_path} ]]; then
+        echo "${config_path}"
+    elif [[ -f $HOME/.config/klone.toml ]]; then
         echo $HOME/.config/klone.toml
     fi
 }
@@ -122,34 +123,36 @@ __klone_helper_parse_toml() {
     # Clear any existing TOML variables
     __klone_helper_cleanup_vars
 
-    while IFS= read -r line; do
-        # Skip empty lines and comments
-        [[ -z "$line" || "$line" =~ ^# ]] && continue
+    if [[ -f $file ]]; then
+        while IFS= read -r line; do
+            # Skip empty lines and comments
+            [[ -z "$line" || "$line" =~ ^# ]] && continue
 
-        # Match section headers
-        if [[ "$line" =~ '^\[(.*)\]$' ]]; then
-            current_section="${match[1]}"
-            continue
-        fi
-
-        # Match key-value pairs
-        if [[ "$line" =~ ^([a-zA-Z0-9_.]+)[[:space:]]*=[[:space:]]*(.*)$ ]]; then
-            local key="${match[1]}"
-            local value="${match[2]}"
-
-            # Remove surrounding quotes if present
-            if [[ "$value" =~ ^\"(.*)\"$ ]]; then
-                value="${match[1]}"
+            # Match section headers
+            if [[ "$line" =~ ^\[(.*)\]$ ]]; then
+                current_section="${BASH_REMATCH[1]}"
+                continue
             fi
 
-            local storage_key="klone_toml_$(__klone_helper_escape_key "${current_section}.${key}")"
-            if [[ "$value" =~ '^\[(.*)\]$' ]]; then
-                __klone_helper_parse_array "$value" "$storage_key"
-            else
-                export "$storage_key=$value"
+            # Match key-value pairs
+            if [[ "$line" =~ ^([a-zA-Z0-9_.]+)[[:space:]]*=[[:space:]]*(.*)$ ]]; then
+                local key="${BASH_REMATCH[1]}"
+                local value="${BASH_REMATCH[2]}"
+
+                # Remove surrounding quotes if present
+                if [[ "$value" =~ ^\"(.*)\"$ ]]; then
+                    value="${BASH_REMATCH[1]}"
+                fi
+
+                local storage_key="klone_toml_$(__klone_helper_escape_key "${current_section}.${key}")"
+                if [[ "$value" =~ ^\[(.*)\]$ ]]; then
+                    __klone_helper_parse_array "$value" "$storage_key"
+                else
+                    export "$storage_key=$value"
+                fi
             fi
-        fi
-    done < "$file"
+        done < "$file"
+    fi
 }
 
 # Function to parse array values

--- a/zsh/klone.sh
+++ b/zsh/klone.sh
@@ -24,8 +24,6 @@ __klone_helper_toml_file() {
     local config_path="${KLONE_CONFIG:-$HOME/.config/klone/config.toml}"
     if [[ -f ${config_path} ]]; then
         echo "${config_path}"
-    elif [[ -f $HOME/.config/klone.toml ]]; then
-        echo $HOME/.config/klone.toml
     fi
 }
 


### PR DESCRIPTION
I've changed the default location of the config file to `~/.config/klone/config.toml` because that's cleaner than just putting it and the script itself into `~/.config` directly. ~~The script still checks the old `~/.config/klone.toml` to avoid breaking existing installations.~~ (EDIT: Dropped the old path entirely after talking to you because there are no existing installations yet)

I've also updated the README accordingly (including the installation instructions) and fixed a few typos along the way.